### PR TITLE
fix: return typed nil from TCPConn Local|RemoteAddr()

### DIFF
--- a/pkg/tcpip/adapters/gonet/gonet.go
+++ b/pkg/tcpip/adapters/gonet/gonet.go
@@ -445,7 +445,7 @@ func (c *TCPConn) CloseWrite() error {
 func (c *TCPConn) LocalAddr() net.Addr {
 	a, err := c.ep.GetLocalAddress()
 	if err != nil {
-		return nil
+		return (*net.TCPAddr)(nil)
 	}
 	return fullToTCPAddr(a)
 }
@@ -454,7 +454,7 @@ func (c *TCPConn) LocalAddr() net.Addr {
 func (c *TCPConn) RemoteAddr() net.Addr {
 	a, err := c.ep.GetRemoteAddress()
 	if err != nil {
-		return nil
+		return (*net.TCPAddr)(nil)
 	}
 	return fullToTCPAddr(a)
 }


### PR DESCRIPTION
related to https://github.com/coder/internal/issues/1143

The gonet adapter returns an _untyped_ nil, which causes a segfault when we try to stringify it.

However, the _typed_ nil in this PR supports `String()` without segfault (it returns `"<nil>"`).