### PR TITLE
fix: fix overflow in tcp.sender.sendData() for 32-bit architectures.

### DIFF
--- a/pkg/tcpip/transport/tcp/cubic.go
+++ b/pkg/tcpip/transport/tcp/cubic.go
@@ -177,7 +177,7 @@ func (c *cubicState) updateSlowStart(packetsAcked int) int {
 	}
 
 	packetsAcked -= newcwnd - c.s.SndCwnd
-	c.s.SndCwnd = newcwnd
+	c.s.SetSndCwnd(newcwnd)
 	if enterCA {
 		c.enterCongestionAvoidance()
 	}
@@ -200,7 +200,7 @@ func (c *cubicState) Update(packetsAcked int, rtt time.Duration) {
 		c.s.rtt.Lock()
 		srtt := c.s.rtt.TCPRTTState.SRTT
 		c.s.rtt.Unlock()
-		c.s.SndCwnd = c.getCwnd(packetsAcked, c.s.SndCwnd, srtt)
+		c.s.SetSndCwnd(c.getCwnd(packetsAcked, c.s.SndCwnd, srtt))
 	}
 }
 
@@ -274,7 +274,7 @@ func (c *cubicState) HandleRTOExpired() {
 	// Reduce the congestion window to 1, i.e., enter slow-start. Per
 	// RFC 5681, page 7, we must use 1 regardless of the value of the
 	// initial congestion window.
-	c.s.SndCwnd = 1
+	c.s.SetSndCwnd(1)
 }
 
 // fastConvergence implements the logic for Fast Convergence algorithm as

--- a/pkg/tcpip/transport/tcp/snd.go
+++ b/pkg/tcpip/transport/tcp/snd.go
@@ -1018,9 +1018,10 @@ func (s *sender) sendData() {
 
 	var dataSent bool
 	for seg := s.writeNext; seg != nil && s.Outstanding < s.SndCwnd; seg = seg.Next() {
-		cwndLimit := (s.SndCwnd - s.Outstanding) * s.MaxPayloadSize
-		if cwndLimit < limit {
-			limit = cwndLimit
+		// NOTE(gvisor.dev/issue/11632): Use uint64 to avoid overflow.
+		cwndLimit := uint64(s.SndCwnd-s.Outstanding) * uint64(s.MaxPayloadSize)
+		if cwndLimit < uint64(limit) {
+			limit = int(cwndLimit)
 		}
 		if s.isAssignedSequenceNumber(seg) && s.ep.SACKPermitted && s.ep.scoreboard.IsSACKED(seg.sackBlock()) {
 			// Move writeNext along so that we don't try and scan data that

--- a/pkg/tcpip/transport/tcp/snd.go
+++ b/pkg/tcpip/transport/tcp/snd.go
@@ -40,6 +40,7 @@ const (
 
 	// InitialCwnd is the initial congestion window.
 	InitialCwnd = 10
+	MaxCwnd     = 1 << 30
 
 	// nDupAckThreshold is the number of duplicate ACK's required
 	// before fast-retransmit is entered.
@@ -270,7 +271,7 @@ func newSender(ep *Endpoint, iss, irs seqnum.Value, sndWnd seqnum.Size, mss uint
 // returns a handle to it. It also initializes the sndCwnd and sndSsThresh to
 // their initial values.
 func (s *sender) initCongestionControl(congestionControlName tcpip.CongestionControlOption) congestionControl {
-	s.SndCwnd = InitialCwnd
+	s.SetSndCwnd(InitialCwnd)
 	s.Ssthresh = InitialSsthresh
 
 	switch congestionControlName {
@@ -1012,15 +1013,19 @@ func (s *sender) sendData() {
 	// the retrasmission timeout."
 	if !s.FastRecovery.Active && s.state != tcpip.RTORecovery && s.ep.stack.Clock().NowMonotonic().Sub(s.LastSendTime) > s.RTO {
 		if s.SndCwnd > InitialCwnd {
-			s.SndCwnd = InitialCwnd
+			s.SetSndCwnd(InitialCwnd)
 		}
 	}
 
 	var dataSent bool
 	for seg := s.writeNext; seg != nil && s.Outstanding < s.SndCwnd; seg = seg.Next() {
-		// NOTE(gvisor.dev/issue/11632): Use uint64 to avoid overflow.
-		cwndLimit := uint64(s.SndCwnd-s.Outstanding) * uint64(s.MaxPayloadSize)
-		if cwndLimit < uint64(limit) {
+		cwndLimit := (s.SndCwnd - s.Outstanding) * s.MaxPayloadSize
+		// cwndLimit being less than zero implies an overflow. This shouldn't be possible since we cap
+		// SndCwnd but just in case.
+		if cwndLimit < 0 {
+			cwndLimit = math.MaxInt
+		}
+		if cwndLimit < limit {
 			limit = int(cwndLimit)
 		}
 		if s.isAssignedSequenceNumber(seg) && s.ep.SACKPermitted && s.ep.scoreboard.IsSACKED(seg.sackBlock()) {
@@ -1054,7 +1059,7 @@ func (s *sender) enterRecovery() {
 	// See : https://tools.ietf.org/html/rfc5681#section-3.2 Step 3.
 	// We inflate the cwnd by 3 to account for the 3 packets which triggered
 	// the 3 duplicate ACKs and are now not in flight.
-	s.SndCwnd = s.Ssthresh + 3
+	s.SetSndCwnd(s.Ssthresh + 3)
 	s.SackedOut = 0
 	s.DupAckCount = 0
 	s.FastRecovery.First = s.SndUna
@@ -1089,7 +1094,7 @@ func (s *sender) leaveRecovery() {
 	s.DupAckCount = 0
 
 	// Deflate cwnd. It had been artificially inflated when new dups arrived.
-	s.SndCwnd = s.Ssthresh
+	s.SetSndCwnd(s.Ssthresh)
 	s.cc.PostRecovery()
 }
 
@@ -1804,4 +1809,12 @@ func (s *sender) corkTimerExpired() tcpip.Error {
 	// Drain all the segments.
 	s.sendData()
 	return nil
+}
+
+func (s *sender) SetSndCwnd(cwnd int) {
+	// If cwnd overflows or exceeds the maximum value, set it to the maximum value.
+	if cwnd < 0 || cwnd > MaxCwnd {
+		cwnd = MaxCwnd
+	}
+	s.SndCwnd = cwnd
 }


### PR DESCRIPTION
I figured I can just reset `coder-main` to the commit we're tracking in upstream gvisor at the moment but I wanted to make sure I'm not deleting anything we'd want to keep the history on. Given that, this PR merges into new a branch that points to the upstream commit that we're currently tracking in gvisor and cherry-picks the commit that fixes the overflow issue.

### Bug repro:

1. Panic shows `gvisor.dev/gvisor/pkg/tcpip/transport/tcp.(*sender).splitSeg(0xc01bc86008, 0xc03d0ac800, 0xfe32de9401bff440)`

`splitSeg` has the following signature: `func (s *sender) splitSeg(seg *segment, size int) {`

which means that `0xfe32de9401bff440` should be evaluated as an int (`-129796711974439872`), which is evidence that it overflowed.

2. `splitSeg` is called from `maybeSendSegment` and is passed local variable `available`

`available` is optionally set to `limit` if it exceeds it, so if `limit` is negative `available` becomes negative.

3. How does `limit` become negative?

The congestion window controls how many bytes we can have in flight. Every time we receive an ACK, CUBIC's `getCwnd` (`cubic.go:215`) grows the window using:

```
cwnd += (wtRtt - cwnd) / cwnd    (cubic.go:244)
```

where `wtRtt = 0.4 * t³ + 30` (`cubic.go:210`) and `t` is the elapsed time since the CUBIC epoch start (`c.T`).

`c.T` is set once when entering congestion avoidance (`cubic.go:102`) and is **only reset by loss events** (`HandleLossDetected` at `cubic.go:253`, `HandleRTOExpired` at `cubic.go:264`). Assuming no loss or retransmission timeout, this means `t` grows unbounded.

Normally the per-ACK increment `(wtRtt - cwnd) / cwnd` would grow `cwnd` gradually, making the division flatten the curve. However, if a connection has no data segments flowing for longer than RTO, the idle check resets `SndCwnd` back to its initial value of 10 (`snd.go:1015`). RTO is `SRTT + 4×RTTVar` clamped to `[200ms, 120s]` (`snd.go:33-36,420-426`) — for Tailscale's virtual network with ~2ms RTT, RTO floors at **200ms**. Note: TCP keepalives (`sendEmptySegment` at `connect.go:1325`) keep the connection alive during idle periods but bypass `sendData` entirely and don't trigger `cc.Update`, so they don't prevent the idle reset from firing on the next real data write.

Critically, the idle reset does NOT reset `c.T`. So after the reset, the next ACK computes `(0.4 × days³ - 10) / 10 ≈ 0.4 × days³ / 10` in a single step, catapulting `SndCwnd` to:

```
1m:  0.4 * 60³ / 10      = 8,640
60m: 0.4 * 3600³ / 10    = 1,866,240,000
24h: 0.4 * 86400³ / 10   = 2.58 × 10¹³
72h: 0.4 * 259200³ / 10  = 6.97 × 10¹⁴
7d:  0.4 * 604800³ / 10  = 8.85 × 10¹⁵
```

After a sufficiently long persistent connection (~7 days) and a period of inactivity that resets `SndCwnd`, the next time we try to send a packet we overflow (`snd.go:1021`):

```go
cwndLimit := (s.SndCwnd - s.Outstanding) * s.MaxPayloadSize
//           (8.85×10¹⁵ -       0)       *      1220
//         = 1.08 × 10¹⁹ // overflows int64 (max 9.22 × 10¹⁸)
if cwndLimit < limit {    // -7.65e18 < 65535? YES
    limit = cwndLimit     // limit = -7.65 × 10¹⁸
}
```

This limit is eventually reassigned to `available` (`snd.go:895`) and then our call on (`snd.go:908`) triggers a panic when checking the length (`snd.go:639`).